### PR TITLE
Add a check on the existence of `__qualname__`

### DIFF
--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -334,6 +334,7 @@ def inspect_namespace(  # noqa C901
         elif (
             isinstance(value, type)
             and value.__module__ == namespace['__module__']
+            and '__qualname__' in namespace
             and value.__qualname__.startswith(namespace['__qualname__'])
         ):
             # `value` is a nested type defined in this namespace; don't error

--- a/tests/test_create_model.py
+++ b/tests/test_create_model.py
@@ -601,3 +601,10 @@ class Y:
     )
     Z = create_model('Z', y=(module.Y, ...))
     assert Z(y={'x': {}}).y is not None
+
+
+def test_type_field_in_the_same_module():
+    class A:
+        pass
+
+    create_model('B', a_cls=(type, A))


### PR DESCRIPTION
## Change Summary
Add a check on the existence of `__qualname__` in the `namespace` in function `inspect_namespace`, to avoid unexpected `KeyError` when setting a type-type default value in `create_model`, which type is defined in the same module.
## Related issue number
fix [#8633](https://github.com/pydantic/pydantic/issues/8633)

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
